### PR TITLE
Fix reflexion parameter ignored

### DIFF
--- a/Auto3dgm_Python.py
+++ b/Auto3dgm_Python.py
@@ -99,15 +99,8 @@ class interface:
             num_cores = int(num_cores_e.get())
         sample_method = sample_method_var.get()
 
-        # determine reflection flag (prefer the explicit BooleanVar)
-        if hasattr(self, 'reflection_var'):
-            reflection = bool(self.reflection_var.get())
-        else:
-            # fallback to previous behavior if the var doesn't exist
-            if reflection_btn["text"] == "Reflection":
-                reflection = True
-            else:
-                reflection = False
+        # determine reflection flag
+        reflection = bool(self.reflection_var.get())
 
         mesh_dir = mesh_dir_entry.get()
         output_dir = output_dir_entry.get()

--- a/Auto3dgm_Python.py
+++ b/Auto3dgm_Python.py
@@ -71,14 +71,15 @@ class interface:
         if not hasattr(self, 'reflection_var'):
             self.reflection_var = tk.BooleanVar(value=True)
 
-        # toggle the boolean state
-        self.reflection_var.set(not self.reflection_var.get())
-
         # update button label to match state
         if self.reflection_var.get():
             self.reflection_btn["text"] = "Reflection"
+            # toggle the boolean state
+            self.reflection_var.set(True)
         else:
             self.reflection_btn["text"] = "No Reflection"
+            # toggle the boolean state
+            self.reflection_var.set(False)
     
 
     # Save settings

--- a/Auto3dgm_Python.py
+++ b/Auto3dgm_Python.py
@@ -71,15 +71,14 @@ class interface:
         if not hasattr(self, 'reflection_var'):
             self.reflection_var = tk.BooleanVar(value=True)
 
+        # toggle the boolean state
+        self.reflection_var.set(not self.reflection_var.get())
+
         # update button label to match state
         if self.reflection_var.get():
             self.reflection_btn["text"] = "Reflection"
-            # toggle the boolean state
-            self.reflection_var.set(True)
         else:
             self.reflection_btn["text"] = "No Reflection"
-            # toggle the boolean state
-            self.reflection_var.set(False)
     
 
     # Save settings

--- a/auto3dgm_nazar/analysis/correspondence.py
+++ b/auto3dgm_nazar/analysis/correspondence.py
@@ -195,7 +195,6 @@ class Correspondence:
     # params: mesh1, mesh2 meshes that have vertices that are 3 x n matrices
     #        mirror: a flag for whether or not mirror images of the shapes should be considered
     def principal_component_alignment(mesh1, mesh2, mirror):
-        mirror = 1
         X = mesh1.vertices.T
         Y = mesh2.vertices.T
         #print(X)


### PR DESCRIPTION
This PR fixes the error where the reflection flag entered by the user was ignored.

It essentially removes the hard-coded flag from the code and uses the user defined input from the GUI to detemine whether to consider reflection transformations.

This solves issue https://github.com/ToothAndClaw/Auto3dgm_Python/issues/3
